### PR TITLE
Add VQC model using Qiskit Machine Learning

### DIFF
--- a/quantum_engine/vqc_model.py
+++ b/quantum_engine/vqc_model.py
@@ -1,0 +1,34 @@
+import numpy as np
+from qiskit import QuantumCircuit, Aer, execute
+from qiskit.circuit.library import ZZFeatureMap, TwoLocal
+from qiskit_machine_learning.algorithms import VQC
+from qiskit_machine_learning.optimizers import COBYLA
+from sklearn.preprocessing import StandardScaler
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import accuracy_score
+
+class VQCModel:
+    def __init__(self, feature_dim, ansatz_reps=3):
+        self.feature_dim = feature_dim
+        self.feature_map = ZZFeatureMap(feature_dimension=feature_dim, reps=2)
+        self.ansatz = TwoLocal(num_qubits=feature_dim, reps=ansatz_reps, rotation_blocks='ry', entanglement_blocks='cz')
+        self.optimizer = COBYLA(maxiter=100)
+        self.vqc = VQC(feature_map=self.feature_map, ansatz=self.ansatz, optimizer=self.optimizer)
+        self.scaler = StandardScaler()
+
+    def prepare_data(self, X, y):
+        X_scaled = self.scaler.fit_transform(X)
+        X_train, X_test, y_train, y_test = train_test_split(X_scaled, y, test_size=0.2, random_state=42)
+        return X_train, X_test, y_train, y_test
+
+    def train(self, X_train, y_train):
+        self.vqc.fit(X_train, y_train)
+
+    def evaluate(self, X_test, y_test):
+        y_pred = self.vqc.predict(X_test)
+        accuracy = accuracy_score(y_test, y_pred)
+        return accuracy
+
+    def predict(self, X):
+        X_scaled = self.scaler.transform(X)
+        return self.vqc.predict(X_scaled)

--- a/routes.py
+++ b/routes.py
@@ -28,6 +28,7 @@ from quantum_engine.god_mode import (
     forge_financial_reality, view_multiverse_balance, activate_chrono_shield,
     connect_to_type4_civilizations
 )
+from quantum_engine.vqc_model import VQCModel
 import json
 import uuid
 import random
@@ -1146,6 +1147,56 @@ def post_singularity_economy():
         
     except Exception as e:
         logging.error(f"Error in post-singularity economy simulation: {e}")
+        return jsonify({
+            'status': 'error',
+            'message': str(e)
+        }), 500
+
+
+@app.route('/api/vqc_prediction', methods=['POST'])
+def vqc_prediction():
+    try:
+        data = request.json
+        simulation_id = data.get('simulation_id')
+        
+        simulation = Simulation.query.get_or_404(simulation_id)
+        
+        # Initialize VQC model
+        feature_dim = data.get('feature_dim', 4)
+        vqc_model = VQCModel(feature_dim=feature_dim)
+        
+        # Prepare data
+        X = np.array(data.get('features'))
+        y = np.array(data.get('labels'))
+        X_train, X_test, y_train, y_test = vqc_model.prepare_data(X, y)
+        
+        # Train VQC model
+        vqc_model.train(X_train, y_train)
+        
+        # Evaluate VQC model
+        accuracy = vqc_model.evaluate(X_test, y_test)
+        
+        # Store prediction in database
+        new_prediction = Prediction(
+            simulation_id=simulation_id,
+            probability_landscape={"accuracy": accuracy},
+            optimal_strategy={"model": "VQC"},
+            quantum_volatility=np.random.uniform(0.1, 1.0),  # Simulated value
+            dark_energy_consumption=np.random.uniform(0.1, 10.0)  # Simulated value
+        )
+        
+        db.session.add(new_prediction)
+        db.session.commit()
+        
+        return jsonify({
+            'status': 'success',
+            'prediction_id': new_prediction.id,
+            'accuracy': accuracy,
+            'message': 'VQC prediction completed successfully'
+        })
+        
+    except Exception as e:
+        logging.error(f"Error in VQC prediction: {e}")
         return jsonify({
             'status': 'error',
             'message': str(e)


### PR DESCRIPTION
Implement the Variable Quantum Classifier (VQC) model using Qiskit Machine Learning.

* **Add `quantum_engine/vqc_model.py`**:
  - Implement data preparation for VQC model.
  - Implement feature map selection using `ZZFeatureMap`.
  - Implement ansatz design using `TwoLocal`.
  - Implement VQC model construction using Qiskit Machine Learning.
  - Implement training and evaluation of VQC model.

* **Modify `routes.py`**:
  - Add a new route `/api/vqc_prediction` to handle VQC predictions.
  - Import `VQCModel` from `quantum_engine/vqc_model`.
  - Implement the logic to handle VQC predictions in the new route.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/behicof/QuantumCrypto/pull/1?shareId=10e7a7b4-a4cc-40a1-b61b-356a5757e045).